### PR TITLE
Enable CORS for external endpoint

### DIFF
--- a/api/external_api.py
+++ b/api/external_api.py
@@ -16,6 +16,7 @@ from database.user_models import Participant, Researcher, StudyRelation
 from database.study_models import Study
 from libs.encryption import decrypt_device_file, DecryptionKeyInvalidError, HandledError
 from libs.http_utils import determine_os_api
+from libs.cors import crossdomain
 from libs.logging import log_error
 from libs.s3 import get_client_private_key, get_client_public_key_string, s3_upload
 from libs.sentry import make_sentry_client
@@ -51,7 +52,8 @@ def contains_valid_selfie_extension(filename):
 #                     headers={'Content-Disposition':'attachment; filename="loaderio-8ed6e63e16e9e4d07d60a051c4ca6ecb.txt"'})
 
 
-@external_api.route('/upload_digital_selfie', methods=['POST'])
+@external_api.route('/upload_digital_selfie', methods=['POST', 'OPTIONS'])
+@crossdomain(origin='*') 
 def upload_digital_selfie():
     """ Entry point to upload GPS, Accelerometer, Audio, PowerState, Calls Log, Texts Log,
     Survey Response, and debugging files to s3.

--- a/libs/cors.py
+++ b/libs/cors.py
@@ -1,0 +1,46 @@
+from datetime import timedelta
+from flask import make_response, request, current_app
+from functools import update_wrapper
+
+
+def crossdomain(origin=None, methods=None, headers=None,
+                max_age=21600, attach_to_all=True,
+                automatic_options=True):
+
+    if methods is not None:
+        methods = ', '.join(sorted(x.upper() for x in methods))
+    if headers is not None and not isinstance(headers, basestring):
+        headers = ', '.join(x.upper() for x in headers)
+    if not isinstance(origin, basestring):
+        origin = ', '.join(origin)
+    if isinstance(max_age, timedelta):
+        max_age = max_age.total_seconds()
+
+    def get_methods():
+        if methods is not None:
+            return methods
+
+        options_resp = current_app.make_default_options_response()
+        return options_resp.headers['allow']
+
+    def decorator(f):
+        def wrapped_function(*args, **kwargs):
+            if automatic_options and request.method == 'OPTIONS':
+                resp = current_app.make_default_options_response()
+            else:
+                resp = make_response(f(*args, **kwargs))
+            if not attach_to_all and request.method != 'OPTIONS':
+                return resp
+
+            h = resp.headers
+
+            h['Access-Control-Allow-Origin'] = origin
+            h['Access-Control-Allow-Methods'] = get_methods()
+            h['Access-Control-Max-Age'] = str(max_age)
+            if headers is not None:
+                h['Access-Control-Allow-Headers'] = headers
+            return resp
+
+        f.provide_automatic_options = False
+        return update_wrapper(wrapped_function, f)
+    return decorator


### PR DESCRIPTION
Enable cross-domain access for a specific endpoint. When a HTTP OPTIONS request is made to the endpoint, to check about its CORS policy, the decorator `crossdomain` will answer by including the CORS headers, allowing the browser to perform the cross-domain request. This request is called `preflight`.

![image](https://user-images.githubusercontent.com/562525/80251176-cd5ef900-863a-11ea-98b7-9c4fcd5b88d5.png)
